### PR TITLE
Fix record examples in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,12 +206,20 @@ This explicit record creation can be done any time you have a record in your rou
 
 ```purescript
   { ...
-  , "Feed": path "feed" $ params { search: optional <<< string }
+  , "Feed": path "feed" $ params { search: optional }
   -- alternately
-  , "Feed": "feed" / params { search: optional <<< string }
+  , "Feed": "feed" / params { search: optional }
   -- alternately
-  , "Feed": "feed" ? { search: optional <<< string }
+  , "Feed": "feed" ? { search: optional }
   }
+```
+
+> NOTE: The recent version of PureScript compiler (e.g. 0.13.3) might have some problems inferring the type of `optional` when used as in the example above.
+> You can work around this by adding type annotation like `(optional :: RouteDuplex' String -> RouteDuplex' (Maybe String))` or by creating a type restricted version of the operator and using that instead:
+
+ ```purescript
+optionalString :: RouteDuplex' String -> RouteDuplex' (Maybe String)
+optionalString = optional
 ```
 
 At this point, our codec is looking much cleaner:
@@ -221,7 +229,7 @@ route = root $ sum
   { "Root": noArgs
   , "Profile": "user" / segment
   , "Post": "user" / segment / "post" / int segment
-  , "Feed": "feed" ? { search: optional <<< string }
+  , "Feed": "feed" ? { search: optional }
   }
 ```
 
@@ -288,9 +296,7 @@ derive instance genericRoute :: Generic Route _
 route :: RouteDuplex' Route
 route = root $ sum
   { ...
-  , "Feed": "feed" ? { search: optional <<< string
-                     , sorting: optional <<< sort
-                     }
+  , "Feed": "feed" ? { search: optional, sorting: optional <<< sort }
   }
 ```
 
@@ -329,9 +335,7 @@ route = root $ sum
   { "Root": noArgs
   , "Profile": "user" / uname
   , "Post": "user" / uname / "post" / postId
-  , "Feed": "feed" ? { search: optional <<< string
-                     , sorting: optional <<< sort
-                     }
+  , "Feed": "feed" ? { search: optional, sorting: optional <<< sort }
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -206,11 +206,11 @@ This explicit record creation can be done any time you have a record in your rou
 
 ```purescript
   { ...
-  , "Feed": path "feed" $ params { search: optional }
+  , "Feed": path "feed" $ params { search: optional <<< string }
   -- alternately
-  , "Feed": "feed" / params { search: optional }
+  , "Feed": "feed" / params { search: optional <<< string }
   -- alternately
-  , "Feed": "feed" ? { search: optional }
+  , "Feed": "feed" ? { search: optional <<< string }
   }
 ```
 
@@ -221,7 +221,7 @@ route = root $ sum
   { "Root": noArgs
   , "Profile": "user" / segment
   , "Post": "user" / segment / "post" / int segment
-  , "Feed": "feed" ? { search: optional }
+  , "Feed": "feed" ? { search: optional <<< string }
   }
 ```
 
@@ -288,7 +288,9 @@ derive instance genericRoute :: Generic Route _
 route :: RouteDuplex' Route
 route = root $ sum
   { ...
-  , "Feed": "feed" ? { search: optional, sorting: optional <<< sort }
+  , "Feed": "feed" ? { search: optional <<< string
+                     , sorting: optional <<< sort
+                     }
   }
 ```
 
@@ -327,7 +329,9 @@ route = root $ sum
   { "Root": noArgs
   , "Profile": "user" / uname
   , "Post": "user" / uname / "post" / postId
-  , "Feed": "feed" ? { search: optional, sorting: optional <<< sort }
+  , "Feed": "feed" ? { search: optional <<< string
+                     , sorting: optional <<< sort
+                     }
   }
 ```
 


### PR DESCRIPTION
Hello @natefaubion,
this library of yours looks pretty amazing! While working through the readme examples, I found some that didn't work. I guess these changes should fix them.

I wonder why aren't the docs for this library uploaded to pursuit? I only learned about it from T. Honeyman's purescript-halogen-realworld..

<details>
  <summary>Here's an example error I was getting with original examples in the readme</summary>
  <pre>
in module Main
at src/Main.purs:56:13 - 56:42 (line 56, column 13 - line 56, column 42)

  No type class instance was found for
                                                                                                                      
    Routing.Duplex.RouteDuplexBuildParams (Cons "search" (RouteDuplex t3 t4 -> RouteDuplex (Maybe t3) (Maybe t4)) Nil)
                                          ( search :: RouteDuplex t3 t4 -> RouteDuplex (Maybe t3) (Maybe t4)          
                                          )                                                                           
                                          ( search :: Maybe String                                                    
                                          )                                                                           
                                          ()                                                                          
                                          ( search :: Maybe String                                                    
                                          )                                                                           
                                                                                                                      
  The instance head contains unknown type variables. Consider adding a type annotation.

while applying a function gparams
  of type GParams t0 t1 t2 => t0 -> t1 -> RouteDuplex t2 t2
  to argument "feed"
while inferring the type of gparams "feed"
in value declaration route

where t0 is an unknown type
      t1 is an unknown type
      t2 is an unknown type
      t4 is an unknown type
      t3 is an unknown type

  </pre>
</details>

PS.: I'm using purescript 0.13.3