### PR TITLE
Add codecs for polymorphic variants

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,8 @@
     "purescript-globals": "^4.0.0",
     "purescript-strings": "^4.0.0",
     "purescript-lazy": "^4.0.0",
-    "purescript-profunctor": "^4.0.0"
+    "purescript-profunctor": "^4.0.0",
+    "purescript-variant": "^6.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -7,8 +7,9 @@ import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.String.Gen (genAlphaString)
 import Data.Symbol (SProxy(..))
+import Data.Variant (Variant)
 import Effect (Effect)
-import Routing.Duplex (RouteDuplex', flag, int, param, parse, print, record, rest, root, segment, string, (:=))
+import Routing.Duplex (RouteDuplex', flag, int, param, parse, prefix, print, record, rest, root, segment, string, variant, (%=), (:=))
 import Routing.Duplex.Generic (noArgs)
 import Routing.Duplex.Generic as RDG
 import Routing.Duplex.Generic.Syntax ((/), (?))
@@ -21,6 +22,7 @@ data TestRoute
   | Foo String Int String { a :: String, b :: Boolean }
   | Bar { id :: String, search :: String }
   | Baz String (Array String)
+  | Qux (Variant (id :: String, search :: String, list :: Unit))
 
 derive instance eqTestRoute :: Eq TestRoute
 derive instance genericTestRoute :: Generic TestRoute _
@@ -41,6 +43,7 @@ genTestRoute = do
 
 _id = SProxy :: SProxy "id"
 _search = SProxy :: SProxy "search"
+_list = SProxy :: SProxy "list"
 
 route :: RouteDuplex' TestRoute
 route =
@@ -49,6 +52,7 @@ route =
     , "Foo": fooRoute
     , "Bar": barRoute
     , "Baz": bazRoute
+    , "Qux": quxRoute
     }
   where
   fooRoute =
@@ -61,6 +65,12 @@ route =
 
   bazRoute =
     segment / rest
+
+  quxRoute =
+    variant
+      # _list %= pure unit
+      # _id %= segment
+      # _search %= prefix "search" segment
 
 main :: Effect Unit
 main = do


### PR DESCRIPTION
Polymorphic `Variant`s are useful for modelling route schemes that follow a common API but that may be expressed partially for different resources in an application. This is where `Generic` based CRUD routes fall short, for example.

The API proposes for `Variant` codecs follows that of `record` and `prop`.

---

I'm not totally sure about the names I chose for `vcase` and `%=`. Happy to take suggestions on those :)