### PR TITLE
update to JSURI (v0.14)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,11 +10,9 @@
   "dependencies": {
     "purescript-prelude": "^4.1.0",
     "purescript-record": "^2.0.0",
-    "purescript-generics-rep": "^6.0.0",
     "purescript-either": "^4.0.0",
     "purescript-control": "^4.1.0",
     "purescript-arrays": "^5.0.0",
-    "purescript-globals": "^4.0.0",
     "purescript-strings": "^4.0.0",
     "purescript-lazy": "^4.0.0",
     "purescript-profunctor": "^4.0.0"

--- a/src/Routing/Duplex.purs
+++ b/src/Routing/Duplex.purs
@@ -45,7 +45,7 @@ import Prim.RowList (RowList, class RowToList, Cons, Nil)
 import Record as Record
 import Routing.Duplex.Parser (RouteParser)
 import Routing.Duplex.Parser as Parser
-import Routing.Duplex.Printer (RoutePrinter)
+import Routing.Duplex.Printer (PrintPathError, RoutePrinter)
 import Routing.Duplex.Printer as Printer
 import Type.Data.RowList (RLProxy(..))
 
@@ -76,12 +76,12 @@ instance profunctorRouteDuplex :: Profunctor RouteDuplex where
 -- | the path, query and fragment (hash) of a URI (see
 -- | [URI - generic syntax](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Generic_syntax))
 -- | or produce a `RouteError` if parsing fails.
-parse :: forall i o. RouteDuplex i o -> String -> Either Parser.RouteError o
+parse :: forall i o. RouteDuplex i o -> String -> Either Parser.RouteParseError o
 parse (RouteDuplex _ dec) = Parser.run dec
 
 -- | Renders a value of type `i` into a String representation of URI path,
 -- | query and fragment (hash).
-print :: forall i o. RouteDuplex i o -> i -> String
+print :: forall i o. RouteDuplex i o -> i -> Either PrintPathError String
 print (RouteDuplex enc _) = Printer.run <<< enc
 
 -- | Strips (when parsing) or adds (when printing) a given string segment of the

--- a/src/Routing/Duplex.purs
+++ b/src/Routing/Duplex.purs
@@ -41,7 +41,7 @@ import Data.String (Pattern(..))
 import Data.String as String
 import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
 import Prim.Row as Row
-import Prim.RowList (kind RowList, class RowToList, Cons, Nil)
+import Prim.RowList (RowList, class RowToList, Cons, Nil)
 import Record as Record
 import Routing.Duplex.Parser (RouteParser)
 import Routing.Duplex.Parser as Parser
@@ -240,7 +240,7 @@ default d (RouteDuplex enc dec) = RouteDuplex enc (Parser.default d dec)
 -- |```purescript
 -- | parse (optional segment) "a"        == Right (Just "a")
 -- | parse (optional segment) ""         == Right Nothing
--- | 
+-- |
 -- | print (optional segment) (Just "a") == "a"
 -- | print (optional segment) Nothing    == ""
 -- |```
@@ -328,7 +328,7 @@ prop sym (RouteDuplex f g) (RouteDuplex x y) =
 
 infix 2 prop as :=
 
-class RouteDuplexParams (r1 :: # Type) (r2 :: # Type) | r1 -> r2 where
+class RouteDuplexParams (r1 :: Row Type) (r2 :: Row Type) | r1 -> r2 where
   -- | Builds a `RouteDuplex` from a record of query parameter parsers/printers, where
   -- | each property corresponds to a query parameter with the same name.
   -- |
@@ -353,7 +353,7 @@ instance routeDuplexParams ::
     record
       # buildParams (RLProxy :: RLProxy rl) r
 
-class RouteDuplexBuildParams (rl :: RowList) (r1 :: # Type) (r2 :: # Type) (r3 :: # Type) (r4 :: # Type) | rl -> r1 r2 r3 r4 where
+class RouteDuplexBuildParams (rl :: RowList Type) (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) (r4 :: Row Type) | rl -> r1 r2 r3 r4 where
   buildParams ::
     RLProxy rl ->
     { | r1 } ->

--- a/src/Routing/Duplex/Generic.purs
+++ b/src/Routing/Duplex/Generic.purs
@@ -17,7 +17,7 @@ sum :: forall a rep r.
   RouteDuplex' a
 sum = dimap from to <<< gRouteDuplex
 
-class GRouteDuplex rep (r :: # Type) | rep -> r where
+class GRouteDuplex rep (r :: Row Type) | rep -> r where
   gRouteDuplex :: { | r } -> RouteDuplex' rep
 
 instance gRouteSum ::

--- a/test/Unit.purs
+++ b/test/Unit.purs
@@ -3,7 +3,7 @@ module Test.Unit (combinatorUnitTests) where
 import Prelude
 
 import Routing.Duplex (RouteDuplex', as, boolean, default, flag, int, many, many1, optional, param, params, parse, path, prefix, print, prop, record, rest, root, segment, string, suffix)
-import Routing.Duplex.Parser (RouteError(..))
+import Routing.Duplex.Parser (RouteError(..), RouteParseError(..))
 import Test.Assert (assertEqual)
 import Effect (Effect)
 import Data.Either (Either(..))
@@ -15,52 +15,52 @@ combinatorUnitTests = do
   -- boolean
   assertEqual { actual: parse (boolean segment) "true",  expected: Right true }
   assertEqual { actual: parse (boolean segment) "false", expected: Right false }
-  assertEqual { actual: parse (boolean segment) "x",     expected: Left (Expected "Boolean" "x") }
-  assertEqual { actual: parse (boolean segment) "",      expected: Left EndOfPath }
+  assertEqual { actual: parse (boolean segment) "x",     expected: Left $ RouteParseError $ Expected "Boolean" "x" }
+  assertEqual { actual: parse (boolean segment) "",      expected: Left $ RouteParseError EndOfPath }
 
   -- prefix
   assertEqual { actual: parse (prefix "api" segment) "api/a",             expected: Right "a" }
   assertEqual { actual: parse (prefix "api" segment) "api/a",             expected: Right "a" }
   assertEqual { actual: parse (prefix "/api/v1" segment) "%2Fapi%2Fv1/a", expected: Right "a" }
-  assertEqual { actual: parse (prefix "/api/v1" segment) "/api/v1/a",     expected: Left (Expected "/api/v1" "") }
+  assertEqual { actual: parse (prefix "/api/v1" segment) "/api/v1/a",     expected: Left $ RouteParseError $ Expected "/api/v1" "" }
 
   -- path
   assertEqual { actual: parse (path "/api/v1" segment) "/api/v1/a", expected: Right "a" }
-  assertEqual { actual: parse (path "/api/v1" segment) "/api/v2/a", expected: Left (Expected "v1" "v2") }
+  assertEqual { actual: parse (path "/api/v1" segment) "/api/v2/a", expected: Left $ RouteParseError $ Expected "v1" "v2" }
 
   -- segment
   assertEqual { actual: parse segment "abc",       expected: Right "abc" }
   assertEqual { actual: parse segment "abc%20def", expected: Right "abc def" }
   assertEqual { actual: parse segment "abc/def",   expected: Right "abc" }
   assertEqual { actual: parse segment "/abc",      expected: Right "" }
-  assertEqual { actual: parse segment "",          expected: Left EndOfPath }
+  assertEqual { actual: parse segment "",          expected: Left $ RouteParseError $ EndOfPath }
 
   -- root
   assertEqual { actual: parse (root segment) "/abc", expected: Right "abc" }
-  assertEqual { actual: parse (root segment) "abc",  expected: Left (Expected "" "abc") }
-  assertEqual { actual: parse (root segment) "/",    expected: Left EndOfPath }
+  assertEqual { actual: parse (root segment) "abc",  expected: Left $ RouteParseError $ Expected "" "abc" }
+  assertEqual { actual: parse (root segment) "/",    expected: Left $ RouteParseError $ EndOfPath }
 
   -- int
   assertEqual { actual: parse (int segment) "1", expected: Right 1 }
-  assertEqual { actual: parse (int segment) "x", expected: Left (Expected "Int" "x") }
+  assertEqual { actual: parse (int segment) "x", expected: Left $ RouteParseError $ Expected "Int" "x" }
 
   -- param
   assertEqual { actual: parse (param "search") "?search=keyword", expected: Right "keyword" }
-  assertEqual { actual: parse (param "search") "/",               expected: Left (MissingParam "search") }
+  assertEqual { actual: parse (param "search") "/",               expected: Left $ RouteParseError $ MissingParam "search" }
   assertEqual { actual: parse (optional (param "search")) "/",    expected: Right Nothing }
 
   -- suffix
   assertEqual { actual: parse (suffix segment "latest") "release/latest", expected: Right "release" }
   assertEqual { actual: parse (suffix segment "latest") "/latest",        expected: Right "" }
   assertEqual { actual: parse (suffix segment "x/y") "a/x%2Fy",           expected: Right "a" }
-  assertEqual { actual: parse (suffix segment "latest") "/",              expected: Left EndOfPath }
-  assertEqual { actual: parse (suffix segment "x/y") "a/x/y",             expected: Left (Expected "x/y" "x") }
+  assertEqual { actual: parse (suffix segment "latest") "/",              expected: Left $ RouteParseError $ EndOfPath }
+  assertEqual { actual: parse (suffix segment "x/y") "a/x/y",             expected: Left $ RouteParseError $ Expected "x/y" "x" }
 
   -- rest
   assertEqual { actual: parse rest "",                     expected: Right [] }
   assertEqual { actual: parse rest "a/b",                  expected: Right ["a", "b"] }
   assertEqual { actual: parse (path "a/b" rest) "a/b/c/d", expected: Right ["c", "d"] }
-  assertEqual { actual: print rest ["a", "b"],             expected: "a/b" }
+  assertEqual { actual: print rest ["a", "b"],             expected: Right "a/b" }
 
   -- default
   assertEqual { actual: parse (default 0 $ int segment) "1", expected: Right 1 }
@@ -68,11 +68,11 @@ combinatorUnitTests = do
 
   -- as
   assertEqual { actual: parse (sort segment) "asc", expected: Right Asc }
-  assertEqual { actual: parse (sort segment) "x",   expected: Left (Expected "asc or desc" "x") }
+  assertEqual { actual: parse (sort segment) "x",   expected: Left $ RouteParseError $ Expected "asc or desc" "x" }
 
   -- many1
   assertEqual { actual: parse (many1 (int segment)) "1/2/3/x", expected: Right [1,2,3] }
-  assertEqual { actual: parse (many1 (int segment)) "x",       expected: Left (Expected "Int" "x") :: Either RouteError (Array Int) }
+  assertEqual { actual: parse (many1 (int segment)) "x",       expected: (Left $ RouteParseError $ Expected "Int" "x") :: Either RouteParseError (Array Int) }
 
   -- many
   assertEqual { actual: parse (many (int segment)) "1/2/3/x", expected: Right [1,2,3] }
@@ -91,8 +91,8 @@ combinatorUnitTests = do
   -- optional
   assertEqual { actual: parse (optional segment) "a",        expected: Right (Just "a") }
   assertEqual { actual: parse (optional segment) "",         expected: Right Nothing }
-  assertEqual { actual: print (optional segment) (Just "a"), expected: "a" }
-  assertEqual { actual: print (optional segment) Nothing,    expected: "" }
+  assertEqual { actual: print (optional segment) (Just "a"), expected: Right "a" }
+  assertEqual { actual: print (optional segment) Nothing,    expected: Right "" }
 
   -- record
   assertEqual { actual: parse (path "blog" date) "blog/2019/1/2", expected: Right { year: 2019, month: 1, day: 2 } }


### PR DESCRIPTION
includes https://github.com/natefaubion/purescript-routing-duplex/pull/12

BREAKING CHANGES

was

```
parse :: forall i o. RouteDuplex i o -> String -> Either Parser.RouteError o
parse (RouteDuplex _ dec) = Parser.run dec

-- | Renders a value of type `i` into a String representation of URI path,
-- | query and fragment (hash).
print :: forall i o. RouteDuplex i o -> i -> String
print (RouteDuplex enc _) = Printer.run <<< enc
```

now

```
data RouteParseError
  = RouteParseError RouteError
  | DecodeURIError String

parse :: forall i o. RouteDuplex i o -> String -> Either Parser.RouteParseError o
parse (RouteDuplex _ dec) = Parser.run dec

newtype PrintPathError = EncodeURIComponentError String

-- | Renders a value of type `i` into a String representation of URI path,
-- | query and fragment (hash).
print :: forall i o. RouteDuplex i o -> i -> Either PrintPathError String
print (RouteDuplex enc _) = Printer.run <<< enc
```