### PR TITLE
Remove unused names

### DIFF
--- a/src/Routing/Duplex.purs
+++ b/src/Routing/Duplex.purs
@@ -240,7 +240,7 @@ default d (RouteDuplex enc dec) = RouteDuplex enc (Parser.default d dec)
 -- |```purescript
 -- | parse (optional segment) "a"        == Right (Just "a")
 -- | parse (optional segment) ""         == Right Nothing
--- | 
+-- |
 -- | print (optional segment) (Just "a") == "a"
 -- | print (optional segment) Nothing    == ""
 -- |```
@@ -378,4 +378,4 @@ instance buildParamsCons ::
 
 instance buildParamsNil ::
   RouteDuplexBuildParams Nil r1 r2 r3 r3 where
-    buildParams _ r = identity
+    buildParams _ _ = identity

--- a/src/Routing/Duplex/Parser.purs
+++ b/src/Routing/Duplex/Parser.purs
@@ -221,7 +221,7 @@ many1 p = Chomp go
   go' :: RouteState -> t a -> RouteResult (t a)
   go' state xs =
     case runRouteParser state p of
-      Fail err -> Success state xs
+      Fail _ -> Success state xs
       Success state' a -> go' state' (xs <|> pure a)
 
 many :: forall t a. Alternative t => RouteParser a -> RouteParser (t a)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -65,7 +65,7 @@ route =
 main :: Effect Unit
 main = do
   combinatorUnitTests
-  
+
   quickCheckGen do
     r <- genTestRoute
     let

--- a/test/Unit.purs
+++ b/test/Unit.purs
@@ -116,7 +116,7 @@ sortFromString :: String -> Either String Sort
 sortFromString = case _ of
   "asc" -> Right Asc
   "desc" -> Right Desc
-  val -> Left $ "asc or desc"
+  _ -> Left $ "asc or desc"
 
 sort :: RouteDuplex' String -> RouteDuplex' Sort
 sort = as sortToString sortFromString


### PR DESCRIPTION
Removes unused names now reported as warnings as of PureScript 0.14.1. (Also fixes a couple of trivial whitespace inconsistencies.)