### PR TITLE
Allow any proxy type in RoutingDuplex' not just SProxy

### DIFF
--- a/src/Routing/Duplex.purs
+++ b/src/Routing/Duplex.purs
@@ -39,7 +39,7 @@ import Data.Maybe (Maybe)
 import Data.Profunctor (class Profunctor)
 import Data.String (Pattern(..))
 import Data.String as String
-import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
+import Data.Symbol (class IsSymbol, reflectSymbol)
 import Prim.Row as Row
 import Prim.RowList (RowList, class RowToList, Cons, Nil)
 import Record as Record
@@ -47,7 +47,7 @@ import Routing.Duplex.Parser (RouteParser)
 import Routing.Duplex.Parser as Parser
 import Routing.Duplex.Printer (RoutePrinter)
 import Routing.Duplex.Printer as Printer
-import Type.Data.RowList (RLProxy(..))
+import Type.Proxy (Proxy(..))
 
 -- | The core abstraction of this library. The values of this type can be used both for parsing
 -- | values of type `o` from `String` as well as printing values of type `i` into `String`.
@@ -303,9 +303,9 @@ string = identity
 -- | ```purescript
 -- | date =
 -- |   record
--- |     # prop (SProxy :: _ "year") (int segment)
--- |     # prop (SProxy :: _ "month") (int segment)
--- |     # prop (SProxy :: _ "day") (int segment)
+-- |     # prop (Proxy :: _ "year") (int segment)
+-- |     # prop (Proxy :: _ "month") (int segment)
+-- |     # prop (Proxy :: _ "day") (int segment)
 -- |
 -- | parse (path "blog" date) "blog/2019/1/2" ==
 -- |   Right { year: 2019, month: 1, day: 2 }
@@ -314,12 +314,12 @@ record :: forall r. RouteDuplex r {}
 record = RouteDuplex mempty (pure {})
 
 -- | See `record`.
-prop :: forall sym a b r1 r2 r3 rx.
+prop :: forall proxy sym a b r1 r2 r3 rx.
   IsSymbol sym =>
   Row.Cons sym a rx r1 =>
   Row.Cons sym b r2 r3 =>
   Row.Lacks sym r2 =>
-  SProxy sym ->
+  proxy sym ->
   RouteDuplex a b ->
   RouteDuplex { | r1 } { | r2 } ->
   RouteDuplex { | r1 } { | r3 }
@@ -351,11 +351,11 @@ instance routeDuplexParams ::
   RouteDuplexParams r1 r2 where
   params r =
     record
-      # buildParams (RLProxy :: RLProxy rl) r
+      # buildParams (Proxy :: Proxy rl) r
 
 class RouteDuplexBuildParams (rl :: RowList Type) (r1 :: Row Type) (r2 :: Row Type) (r3 :: Row Type) (r4 :: Row Type) | rl -> r1 r2 r3 r4 where
   buildParams ::
-    RLProxy rl ->
+    Proxy rl ->
     { | r1 } ->
     RouteDuplex { | r2 } { | r3 } ->
     RouteDuplex { | r2 } { | r4 }
@@ -372,9 +372,9 @@ instance buildParamsCons ::
   buildParams _ r prev =
     prev
       # prop sym ((Record.get sym r) (param (reflectSymbol sym)))
-      # buildParams (RLProxy :: RLProxy rest) r
+      # buildParams (Proxy :: Proxy rest) r
     where
-    sym = SProxy :: SProxy sym
+    sym = Proxy :: Proxy sym
 
 instance buildParamsNil ::
   RouteDuplexBuildParams Nil r1 r2 r3 r3 where

--- a/src/Routing/Duplex/Generic.purs
+++ b/src/Routing/Duplex/Generic.purs
@@ -5,10 +5,11 @@ import Prelude
 import Control.Alt ((<|>))
 import Data.Generic.Rep (class Generic, Argument(..), Constructor(..), NoArguments(..), Product(..), Sum(..), from, to)
 import Data.Profunctor (dimap)
-import Data.Symbol (class IsSymbol, SProxy(..))
+import Data.Symbol (class IsSymbol)
 import Prim.Row as Row
 import Record as Record
 import Routing.Duplex (RouteDuplex(..), RouteDuplex', end)
+import Type.Proxy (Proxy(..))
 
 sum :: forall a rep r.
   Generic a rep =>
@@ -45,7 +46,7 @@ instance gRouteConstructor ::
     RouteDuplex enc' dec' =
       end
         $ (gRouteDuplexCtr :: RouteDuplex' a -> RouteDuplex' b)
-        $ Record.get (SProxy :: SProxy sym) r
+        $ Record.get (Proxy :: Proxy sym) r
     enc (Constructor a) = enc' a
     dec = Constructor <$> dec'
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -6,7 +6,6 @@ import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Show.Generic (genericShow)
 import Data.String.Gen (genAlphaString)
-import Data.Symbol (SProxy(..))
 import Effect (Effect)
 import Routing.Duplex (RouteDuplex', flag, int, param, parse, print, record, rest, root, segment, string, (:=))
 import Routing.Duplex.Generic (noArgs)
@@ -15,6 +14,7 @@ import Routing.Duplex.Generic.Syntax ((/), (?))
 import Test.QuickCheck (Result(..), arbitrary, quickCheckGen, (===))
 import Test.QuickCheck.Gen (Gen, arrayOf, chooseInt)
 import Test.Unit (combinatorUnitTests)
+import Type.Proxy (Proxy(..))
 
 data TestRoute
   = Root
@@ -39,8 +39,8 @@ genTestRoute = do
     3 -> Bar <$> ({ id: _, search: _ } <$> genAlphaString <*> genAlphaString)
     _ -> Baz <$> genAlphaString <*> (arrayOf genAlphaString)
 
-_id = SProxy :: SProxy "id"
-_search = SProxy :: SProxy "search"
+_id = Proxy :: Proxy "id"
+_search = Proxy :: Proxy "search"
 
 route :: RouteDuplex' TestRoute
 route =

--- a/test/Unit.purs
+++ b/test/Unit.purs
@@ -8,7 +8,7 @@ import Test.Assert (assertEqual)
 import Effect (Effect)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
-import Data.Symbol (SProxy(..))
+import Type.Proxy (Proxy(..))
 
 combinatorUnitTests :: Effect Unit
 combinatorUnitTests = do
@@ -124,9 +124,9 @@ sort = as sortToString sortFromString
 date :: RouteDuplex' { year :: Int, month :: Int, day :: Int }
 date =
   record
-    # prop (SProxy :: _ "year") (int segment)
-    # prop (SProxy :: _ "month") (int segment)
-    # prop (SProxy :: _ "day") (int segment)
+    # prop (Proxy :: _ "year") (int segment)
+    # prop (Proxy :: _ "month") (int segment)
+    # prop (Proxy :: _ "day") (int segment)
 
 search :: RouteDuplex' { page :: Int, filter :: Maybe String }
 search =


### PR DESCRIPTION
The `SProxy` type has been deprecated in PureScript 0.14, but `RouteDuplex'` still requires one. This change updates the constraint so that any proxy type can be used. That means that `SProxy` can still be used, but the more usual `Proxy` type can also be used. This is therefore not a breaking change.

I also updated the library internals to use `Proxy` so that we don't have to do anything when PureScript 0.15 comes out and the `SProxy` type is removed.