### PR TITLE
Handle spaces encoded as `+` in query parameters

### DIFF
--- a/src/Routing/Duplex/Parser.purs
+++ b/src/Routing/Duplex/Parser.purs
@@ -42,7 +42,7 @@ import Data.String (Pattern(..), split)
 import Data.String.CodeUnits as String
 import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..))
-import JSURI (decodeURIComponent)
+import JSURI (decodeFormURLComponent, decodeURIComponent)
 import Routing.Duplex.Types (RouteParams, RouteState)
 
 data RouteResult a
@@ -179,7 +179,7 @@ parsePath =
     splitNonEmpty (Pattern "&") >>> traverse splitKeyValue
 
   splitKeyValue =
-    splitAt (flip Tuple "") "=" >>> bitraverse decodeURIComponent' decodeURIComponent'
+    splitAt (flip Tuple "") "=" >>> bitraverse decodeFormURLComponent' decodeFormURLComponent'
 
   splitNonEmpty _ "" = []
   splitNonEmpty p s = split p s
@@ -193,6 +193,10 @@ parsePath =
       Nothing -> k str
 
   decodeURIComponent' str = case decodeURIComponent str of
+    Nothing -> Left (MalformedURIComponent str)
+    Just a -> Right a
+
+  decodeFormURLComponent' str = case decodeFormURLComponent str of
     Nothing -> Left (MalformedURIComponent str)
     Just a -> Right a
 


### PR DESCRIPTION
The function `parsePath` currently uses [`decodeURIComponent`](https://pursuit.purescript.org/packages/purescript-js-uri/3.1.0/docs/JSURI#v:decodeURIComponent).

However, this function is not suitable for decoding query parameters. Source: [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent#decoding_query_parameters_from_a_url).

In query parameters, spaces are allowed to be encoded as either `%20` or as `+`. But `decodeURIComponent` only decodes `%20`. The character `+` is not decoded.

For example: in Chrome, when you setup a "search engine" (`chrome://settings/searchEngines`) for a website, and then type `<shortcut> a b` in the omnibox, it'll generate a url with a query parameter of `a+b`. With the current version of `purescript-routing-duplex`, this will be decoded as `a+b`, when in reality it should be decoded as `a b`.


MDN recommends running `.replace(/\+/g, " ")` before calling `decodeURIComponent`. Luckily, the package `purescript-js-uri` already provides a function that does just this, [`decodeFormURLComponent`](https://pursuit.purescript.org/packages/purescript-js-uri/3.1.0/docs/JSURI#v:decodeFormURLComponent).

This PR fixes `parsePath` to use `decodeFormURLComponent` instead of `decodeURIComponent` for parsing query parameters.